### PR TITLE
fix(resenvs): now hides warning message when no versions are incompatible 

### DIFF
--- a/cwlab_metadata.yml
+++ b/cwlab_metadata.yml
@@ -4,8 +4,7 @@ port: 80
 needs_forc_support: True
 forc_versions:
     - v01
-incompatible_versions:
-    - None known
+incompatible_versions: []
 direction: "ingress"
 protocol: "tcp"
 securitygroup_name: "_cwlab"


### PR DESCRIPTION
@eKatchko 

Test with WebApp version https://github.com/deNBI/cloud-portal-webapp/pull/2644
 
fix deNBI/resenvs#21

Now hides warning at CWLab because there are no incompatible versions, you need to put

GITHUB_PLAYBOOKS_REPO=https://api.github.com/repos/deNBI/resenvs/contents/?ref=fix/cwlab_unsupported_version

at the client .env