### PR TITLE
Feat/cwl containers vscodeplugin

### DIFF
--- a/vscode/cwl.yml
+++ b/vscode/cwl.yml
@@ -10,3 +10,8 @@
     - cwltool
   remote_user: ubuntu
   become: false
+
+- name: Install VSCode CWL Lanquage Support Plugin
+  ansible.builtin.shell: code-server --install-extension sbg-rabix.benten-cwl
+  args:
+    executable: /bin/bash

--- a/vscode/nextflow.yml
+++ b/vscode/nextflow.yml
@@ -11,7 +11,7 @@
     - nextflow
   remote_user: ubuntu
   become: false
-  
+
 - name: Install VSCode Nextflow Lanquage Support Plugin
   ansible.builtin.shell: code-server --install-extension nextflow.nextflow
   args:


### PR DESCRIPTION
Install CWL language server plugin in vscode.
Currently waiting for a pull request to be merged for the upstream plugin to fix an issue with preview rendering of the CWL graph. https://github.com/rabix/benten/pull/121